### PR TITLE
Add json logging to perpetuo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,7 +997,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "perpetuo"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "bytemuck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,7 +997,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "perpetuo"
-version = "0.5.0"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1011,6 +1011,8 @@ dependencies = [
  "pyo3",
  "pyo3-build-config",
  "remoteprocess",
+ "serde",
+ "serde_json",
  "windows-sys 0.48.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perpetuo"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perpetuo"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -26,6 +26,8 @@ proc-maps = "0.3.0"
 py-spy = { git = "https://github.com/benfred/py-spy.git", rev = "7cbbc015980c5db4d517b62523cf8488296fa2fd" }
 pyo3 = { version = "0.18.3", features = ["extension-module", "abi3", "abi3-py39"] }
 remoteprocess = "0.4.13"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [patch.crates-io]
 remoteprocess = { git = "https://github.com/njsmith/remoteprocess", branch = "static-link" }

--- a/example.py
+++ b/example.py
@@ -35,7 +35,7 @@ async def main():
     print(f"{thread.ident=} {thread.native_id=}")
     async with trio.open_nursery() as nursery:
         nursery.start_soon(
-            partial(trio.to_thread.run_sync, gil_naughty)
+            partial(trio.to_thread.run_sync, gil_naughty, cancellable=True)
         )
         await foo()
 

--- a/example.py
+++ b/example.py
@@ -35,7 +35,7 @@ async def main():
     print(f"{thread.ident=} {thread.native_id=}")
     async with trio.open_nursery() as nursery:
         nursery.start_soon(
-            partial(trio.to_thread.run_sync, gil_naughty, cancellable=True)
+            partial(trio.to_thread.run_sync, gil_naughty)
         )
         await foo()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel", "setuptools-rust"]
 
 [project]
 name = "perpetuo"
-version = "0.5.2"
+version = "0.6.0"
 authors = [
   {name = "Nathaniel J. Smith", email = "njs@pobox.com"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel", "setuptools-rust"]
 
 [project]
 name = "perpetuo"
-version = "0.5.1"
+version = "0.5.2"
 authors = [
   {name = "Nathaniel J. Smith", email = "njs@pobox.com"},
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod shmem;
+pub mod log;
 
 use crate::shmem::{alloc_slot, release_slot, StallTracker, ThreadHint, GIL};
 use pyo3::exceptions::{PyRuntimeError, PyValueError};

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,5 +1,6 @@
 use serde::Serialize;
 use std::collections::HashMap;
+use py_spy::StackTrace;
 
 #[derive(Serialize, Debug, Clone, Copy)]
 #[serde(rename_all = "UPPERCASE")]
@@ -13,24 +14,108 @@ pub enum Severity {
 }
 
 #[derive(Serialize)]
+struct StackFrame {
+    name: String,
+    filename: String,
+    line: i32,
+    locals: Option<Vec<LocalVariable>>,
+}
+
+#[derive(Serialize)]
+struct LocalVariable {
+    name: String,
+    value: String,
+}
+
+#[derive(Serialize)]
 struct LogEntry<'a> {
     severity: Severity,
     message: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
     additional_info: Option<&'a HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    traceback: Option<&'a Vec<serde_json::Value>>,
+    traceback: Option<&'a Vec<StackFrame>>,
 }
 
-pub fn log_json(severity: Severity, message: &str, additional_info: Option<&HashMap<String, String>>, traceback: Option<&Vec<serde_json::Value>>) {
-    let entry = LogEntry {
-        severity,
-        message,
-        additional_info,
-        traceback,
-    };
+pub fn log(severity: Severity, message: &str, additional_info: Option<&HashMap<String, String>>, json_mode: bool) {
+    log_with_traceback(severity, message, additional_info, None, json_mode);
+}
 
-    if let Ok(json) = serde_json::to_string(&entry) {
-        eprintln!("{}", json);
+fn log_with_traceback(severity: Severity, message: &str, additional_info: Option<&HashMap<String, String>>, traceback: Option<&Vec<StackFrame>>, json_mode: bool) {
+    if json_mode {
+        let entry = LogEntry {
+            severity,
+            message,
+            additional_info,
+            traceback,
+        };
+
+        if let Ok(json) = serde_json::to_string(&entry) {
+            eprintln!("{}", json);
+        }
+    } else {
+        let severity_str = format!("{:?}", severity);
+        eprintln!("[{}] {}", severity_str, message);
+        if let Some(info) = additional_info {
+            for (key, value) in info {
+                eprintln!("  {}: {}", key, value);
+            }
+        }
+        if let Some(trace) = traceback {
+            eprintln!("Traceback:");
+            for frame in trace {
+                eprintln!("        {} ({}:{})", frame.name, frame.filename, frame.line);
+                if let Some(locals) = &frame.locals {
+                    for local in locals {
+                        eprintln!(
+                            "            {} = {}",
+                            local.name,
+                            local.value
+                        );
+                    }
+                }
+            }
+        }
     }
+}
+
+pub fn dump_stacktrace(trace: &StackTrace, json_mode: bool) {
+    let mut frames = Vec::new();
+    for frame in trace.frames.iter().rev() {
+        let mut locals = None;
+        if let Some(frame_locals) = &frame.locals {
+            locals = Some(
+                frame_locals
+                    .iter()
+                    .map(|local| LocalVariable {
+                        name: local.name.to_string(),
+                        value: local.repr.as_deref().unwrap_or("?").to_string(),
+                    })
+                    .collect(),
+            );
+        }
+
+        frames.push(StackFrame {
+            name: frame.name.clone(),
+            filename: frame.filename.clone(),
+            line: frame.line,
+            locals,
+        });
+    }
+
+    let mut additional_info = HashMap::new();
+    additional_info.insert("thread_id".to_string(), format!("{:x}", trace.thread_id));
+    additional_info.insert("status".to_string(), trace.status_str().to_string());
+    additional_info.insert("owns_gil".to_string(), trace.owns_gil.to_string());
+
+    log_with_traceback(
+        Severity::Info,
+        &format!(
+            "Thread {:x}",
+            trace.thread_id,
+        ),
+        Some(&additional_info),
+        Some(&frames),
+        json_mode,
+    );
 }

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,0 +1,33 @@
+use serde::Serialize;
+use std::collections::HashMap;
+
+#[derive(Serialize, Debug, Clone, Copy)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum Severity {
+    Default,
+    Debug,
+    Info,
+    Notice,
+    Warning,
+    Error,
+}
+
+#[derive(Serialize)]
+struct LogEntry<'a> {
+    severity: Severity,
+    message: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    additional_info: Option<&'a HashMap<String, String>>,
+}
+
+pub fn log_json(severity: Severity, message: &str, additional_info: Option<&HashMap<String, String>>) {
+    let entry = LogEntry {
+        severity,
+        message,
+        additional_info,
+    };
+
+    if let Ok(json) = serde_json::to_string(&entry) {
+        eprintln!("{}", json);
+    }
+}

--- a/src/log.rs
+++ b/src/log.rs
@@ -18,13 +18,16 @@ struct LogEntry<'a> {
     message: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
     additional_info: Option<&'a HashMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    traceback: Option<&'a Vec<serde_json::Value>>,
 }
 
-pub fn log_json(severity: Severity, message: &str, additional_info: Option<&HashMap<String, String>>) {
+pub fn log_json(severity: Severity, message: &str, additional_info: Option<&HashMap<String, String>>, traceback: Option<&Vec<serde_json::Value>>) {
     let entry = LogEntry {
         severity,
         message,
         additional_info,
+        traceback,
     };
 
     if let Ok(json) = serde_json::to_string(&entry) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,7 +175,7 @@ fn check_once(
         );
         let now = Instant::now();
         if now < *next_traceback {
-            log_json(Severity::Warning, "  (no traceback due to rate-limiting)", None, None);
+            log_json(Severity::Warning, &format!("No traceback due to rate-limiting for pid {}", proc.spy.process.pid), Some(&additional_info), None);
             continue;
         }
         *next_traceback = now + traceback_interval;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use anyhow::{bail, Result};
 use clap::{ArgAction, Parser, Subcommand};
 use indoc::indoc;
 use py_spy::StackTrace;
+use serde_json::Value;
 
 use perpetuo::shmem::PerpetuoProc;
 use perpetuo::log::{log_json, Severity};
@@ -82,7 +83,7 @@ fn watch_process(pid: u32, cli: &Cli) -> Result<()> {
     config.full_filenames = true;
     let mut additional_info = HashMap::new();
     additional_info.insert("pid".to_string(), pid.to_string());
-    log_json(Severity::Info, &format!("Attempting to monitor pid {pid}..."), Some(&additional_info));
+    log_json(Severity::Info, &format!("Attempting to monitor pid {pid}..."), Some(&additional_info), None);
     // let mut proc = loop {
     //     if let Some(proc) = PerpetuoProc::new(pid, &config)? {
     //         break proc;
@@ -121,7 +122,7 @@ fn watch_process(pid: u32, cli: &Cli) -> Result<()> {
         }
     }
     let mut proc = result?;
-    log_json(Severity::Info, &format!("Successfully monitoring pid {pid}"), Some(&additional_info));
+    log_json(Severity::Info, &format!("Successfully monitoring pid {pid}"), Some(&additional_info), None);
     let mut next_traceback = Instant::now();
     loop {
         std::thread::sleep(cli.poll_interval);
@@ -132,7 +133,7 @@ fn watch_process(pid: u32, cli: &Cli) -> Result<()> {
             cli.traceback_suppress,
         ) {
             if proc.spy.process.exe().is_err() {
-                log_json(Severity::Info, &format!("Process {} has exited", pid), Some(&additional_info));
+                log_json(Severity::Info, &format!("Process {} has exited", pid), Some(&additional_info), None);
                 return Ok(());
             }
             return Err(err);
@@ -170,14 +171,15 @@ fn check_once(
             Severity::Warning,
             &format!("{} stall detected in process {} for at least {:?}", stall.name, proc.spy.process.pid, stall.duration),
             Some(&additional_info),
+            None,
         );
         let now = Instant::now();
         if now < *next_traceback {
-            log_json(Severity::Warning, "  (no traceback due to rate-limiting)", None);
+            log_json(Severity::Warning, "  (no traceback due to rate-limiting)", None, None);
             continue;
         }
         *next_traceback = now + traceback_interval;
-        log_json(Severity::Info, &format!("command line: {:?}", proc.spy.process.cmdline()?), None);
+        log_json(Severity::Info, &format!("command line: {:?}", proc.spy.process.cmdline()?), None, None);
         let traces = proc.spy.get_stack_traces()?;
         let mut relevant = Vec::new();
         let mut rest = Vec::new();
@@ -189,14 +191,14 @@ fn check_once(
             }
         }
         if !relevant.is_empty() {
-            log_json(Severity::Warning, "This thread is probably responsible:", Some(&additional_info));
+            log_json(Severity::Warning, "This thread is probably responsible:", Some(&additional_info), None);
             for trace in &relevant {
                 dump_stacktrace(trace);
             }
         }
         if !rest.is_empty() {
             if !relevant.is_empty() {
-                log_json(Severity::Info, "Other threads (probably not responsible):", Some(&additional_info));
+                log_json(Severity::Info, "Other threads (probably not responsible):", Some(&additional_info), None);
             }
             for trace in &rest {
                 dump_stacktrace(trace);
@@ -207,37 +209,42 @@ fn check_once(
 }
 
 fn dump_stacktrace(trace: &StackTrace) {
+    let mut frames = Vec::new();
+    for frame in trace.frames.iter().rev() {
+        let mut frame_info = serde_json::json!({
+            "name": frame.name,
+            "filename": frame.filename,
+            "line": frame.line,
+        });
+
+        if let Some(locals) = &frame.locals {
+            let locals_info: Vec<Value> = locals
+                .iter()
+                .map(|local| {
+                    serde_json::json!({
+                        "name": local.name,
+                        "value": local.repr.as_deref().unwrap_or("?")
+                    })
+                })
+                .collect();
+            frame_info["locals"] = serde_json::json!(locals_info);
+        }
+
+        frames.push(frame_info);
+    }
+
+    let mut additional_info = HashMap::new();
+    additional_info.insert("thread_id".to_string(), format!("{:x}", trace.thread_id));
+    additional_info.insert("status".to_string(), trace.status_str().to_string());
+    additional_info.insert("owns_gil".to_string(), trace.owns_gil.to_string());
+
     log_json(
         Severity::Info,
         &format!(
-            "    Thread {:x} ({}{})",
+            "Thread {:x}",
             trace.thread_id,
-            trace.status_str(),
-            if trace.owns_gil { ", holding GIL" } else { "" }
         ),
-        None,
+        Some(&additional_info),
+        Some(&frames),
     );
-
-    for frame in trace.frames.iter().rev() {
-        log_json(
-            Severity::Info,
-            &format!("        {} ({}:{})", frame.name, frame.filename, frame.line),
-            None,
-        );
-
-        if let Some(locals) = &frame.locals {
-            for local in locals {
-                log_json(
-                    Severity::Info,
-                    &format!(
-                        "            {} = {}",
-                        local.name,
-                        local.repr.as_deref().unwrap_or("?")
-                    ),
-                    None,
-                );
-            }
-        }
-    }
-    log_json(Severity::Info, "", None);
 }


### PR DESCRIPTION
Did not change any of the message statements. Added json logging for GKE compatibility and jq parsing.

1. pip uninstall perpetuo
2. pip install /Users/rohit/code/perpetuo
3. python example.py
4. `sudo perpetuo watch 44262` & `sudo perpetuo --json-mode watch 95271`