### PR TITLE
Add PR_SET_PDEATHSIG to ensure watcher process terminates when parent dies

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -64,6 +64,19 @@ enum Commands {
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
+    // Set up death signal before doing anything else
+    #[cfg(target_os = "linux")]
+    unsafe {
+        // SIGTERM = 15
+        if libc::prctl(libc::PR_SET_PDEATHSIG, 15, 0, 0, 0) != 0 {
+            log(Severity::Warning, 
+                "Failed to set PR_SET_PDEATHSIG - watcher may not exit properly if parent dies",
+                None,
+                cli.json_mode
+            );
+        }
+    }
+
     match cli.command {
         Commands::Watch { pid } => watch_process(pid, &cli)?,
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,8 +67,7 @@ fn main() -> Result<()> {
     // Set up death signal before doing anything else
     #[cfg(target_os = "linux")]
     unsafe {
-        // SIGTERM = 15
-        if libc::prctl(libc::PR_SET_PDEATHSIG, 15, 0, 0, 0) != 0 {
+        if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM, 0, 0, 0) != 0 {
             log(Severity::Warning, 
                 "Failed to set PR_SET_PDEATHSIG - watcher may not exit properly if parent dies",
                 None,


### PR DESCRIPTION
This change ensures that on Linux systems, if the parent Python process dies unexpectedly, the kernel will automatically send SIGTERM to the watcher process, preventing it from becoming a zombie process.