### PR TITLE
Fix print_locals=False

### DIFF
--- a/python/perpetuo/_setup.py
+++ b/python/perpetuo/_setup.py
@@ -44,10 +44,10 @@ def start_watcher(
             args += ["--traceback-suppress", str(alert_interval)]
         if print_locals:
             args += ["--print-locals"]
-        if json_mode:
-            args += ["--json-mode"]
         else:
             args += ["--no-print-locals"]
+        if json_mode:
+            args += ["--json-mode"]
         process = subprocess.Popen(["perpetuo", *args, "watch", str(os.getpid())])
         if sys.platform == "linux":
             try:


### PR DESCRIPTION
The recent changes to add support for JSON mode accidentally broke setting `print_locals=False`, so Perpetuo would always print locals.